### PR TITLE
Update config.ts for tasks

### DIFF
--- a/config.ts
+++ b/config.ts
@@ -28,7 +28,7 @@ config.git = {
   content_tag_latest: "1.1.2",
 };
 
-config.api.db_name = "wash"
+config.api.db_name = "wash";
 config.app_data.output_path = "./app_data";
 
 config.app_config.APP_LANGUAGES.default = "tz_sw";
@@ -36,7 +36,9 @@ config.app_config.APP_SIDEMENU_DEFAULTS!.title = "WASH App";
 config.app_config.APP_HEADER_DEFAULTS!.title = "WASH App";
 config.app_config.NOTIFICATION_DEFAULTS!.title = "New message from WASH App";
 config.app_config.NOTIFICATION_DEFAULTS!.text = "You have a new message from WASH App";
-config.app_config.APP_UPDATES.enabled = true
-config.app_config.APP_UPDATES.completeUpdateTemplate = "app_update_complete"
+config.app_config.TASKS.enabled = true;
+config.app_config.TASKS.taskGroupsListName = "module_tasks";
+config.app_config.APP_UPDATES.enabled = true;
+config.app_config.APP_UPDATES.completeUpdateTemplate = "app_update_complete";
 
 export default config;


### PR DESCRIPTION
Post merge of https://github.com/IDEMSInternational/parenting-app-ui/pull/2176 we need the config of the WASH App to specify it uses the tasks system, and what the main task group is called.

This is the equivalent of commit https://github.com/IDEMSInternational/parenting-app-ui/commit/ad06fb3f0401f0bee628c48e12942e126e21419d. I believe the WASH deployment branches on the code repo can finally be removed after this PR has been merged